### PR TITLE
Festival-Edit-Race beheben + DB-Sync sicherer (kein force ausserhalb Tests)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,7 @@ Sortiert nach **Aufwand** (S → M → L), innerhalb jeder Stufe nach **Priorit�
 - [ ] 🟢 **API-Body vereinheitlichen:** Der `join`-Endpoint liest `request.json()`, `cancel-invitation` dagegen `request.blob()` → `.text()` (Kommentar als Roh-Textbody). Auf ein einheitliches JSON-Format für beide Endpoints (inkl. Client in `festival/[festival_id]/+page.svelte`) umstellen. _(Datenbank)_
 - [ ] 🟢 **`alert()` ersetzen:** In `src/routes/festival/[festival_id]/+page.svelte` (Join-Fehlerpfad) wird noch natives `alert()` genutzt. Durch den vorhandenen `InfoDialog` ersetzen, konsistent zum Rest der App. _(UX)_
 - [ ] 🟢 **Bild-Store-Cache:** `src/lib/stores/userImage.store.ts` hält eine modulweite `Map<string, Writable>`, die auf dem Client nie geleert wird (wächst mit jedem betrachteten Profil). Cache-Größe begrenzen oder Einträge bei Bedarf invalidieren. _(Performance)_
+- [ ] 🟢 **Dialog-Vorbefüllung entkoppeln:** In `festival/[festival_id]/+page.svelte` synchronisiert ein `$effect` laufend die Zu-/Absage-Dialogfelder (`bind:value`) aus abgeleiteten Gastdaten. Latent dieselbe Hydration-/Überschreib-Race wie in der Edit-Seite (nur unkritischer, da der Dialog erst auf Klick öffnet). Sauberer: die Felder **beim Öffnen** des Dialogs einmalig setzen statt via Dauer-Effect. _(UX)_
 
 ## [M] Mittel (1–4h)
 

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -9,8 +9,6 @@ import { FriendRequest } from '$lib/db/model/friendRequest';
 import { GroupMember } from '$lib/db/model/groupMember';
 import { Friendship } from '$lib/db/model/friendship';
 import { Comment } from '$lib/db/model/comment';
-import { env } from '$env/dynamic/private';
-const { MARIA_DB_NAME } = env;
 
 FestivalEvent.hasMany(GuestInformation, { as: 'EventGuests', foreignKey: 'FestivalEventId', onDelete: 'CASCADE' });
 GuestInformation.belongsTo(FestivalEvent, { foreignKey: 'FestivalEventId', as: 'FestivalEvent' });
@@ -91,10 +89,13 @@ export async function startDB(): Promise<void> {
 		await sequelize.authenticate();
 		console.log('Connection has been established successfully.');
 
-		const isSyncForced = process.env.PLAYWRIGHT === 'true' || process.env.NODE_ENV === 'test' || MARIA_DB_NAME == 'dev';
-		// force und alter schließen sich gegenseitig aus: bei force wird die Tabelle ohnehin neu erstellt,
-		// alter greift nur beim nicht-forcierten Sync (Produktion).
-		await sequelize.sync(isSyncForced ? { force: true } : { alter: true });
+		// force (löscht und erstellt alle Tabellen neu) NUR für die automatisierten Test-Runner,
+		// die pro Lauf frische Tabellen brauchen. Alle anderen Umgebungen – inkl. dev und
+		// Produktion – nutzen alter, damit vorhandene Daten erhalten bleiben und NICHT
+		// überschrieben werden. force und alter schließen sich gegenseitig aus.
+		const isTestRunner =
+			process.env.PLAYWRIGHT === 'true' || process.env.NODE_ENV === 'test' || process.env.VITEST === 'true';
+		await sequelize.sync(isTestRunner ? { force: true } : { alter: true });
 		dbStarted = true;
 	} catch (error) {
 		console.error('Unable to connect to the database:', error);

--- a/src/lib/db/db.ts
+++ b/src/lib/db/db.ts
@@ -89,13 +89,12 @@ export async function startDB(): Promise<void> {
 		await sequelize.authenticate();
 		console.log('Connection has been established successfully.');
 
-		// force (löscht und erstellt alle Tabellen neu) NUR für die automatisierten Test-Runner,
-		// die pro Lauf frische Tabellen brauchen. Alle anderen Umgebungen – inkl. dev und
-		// Produktion – nutzen alter, damit vorhandene Daten erhalten bleiben und NICHT
-		// überschrieben werden. force und alter schließen sich gegenseitig aus.
-		const isTestRunner =
-			process.env.PLAYWRIGHT === 'true' || process.env.NODE_ENV === 'test' || process.env.VITEST === 'true';
-		await sequelize.sync(isTestRunner ? { force: true } : { alter: true });
+		// Immer alter: In den Test-/Dev-Umgebungen läuft die DB als frisches In-Memory-SQLite
+		// (siehe sequelize.ts) – dort erzeugt alter die Tabellen ohnehin von Grund auf. In
+		// Produktion (echte MariaDB) erhält alter vorhandene Daten. Ein force (kompletter
+		// Wipe) wird also nirgends benötigt. Sauberkeit zwischen E2E-Tests macht der
+		// /api/test/reset-Endpoint, nicht der Sync-Modus.
+		await sequelize.sync({ alter: true });
 		dbStarted = true;
 	} catch (error) {
 		console.error('Unable to connect to the database:', error);

--- a/src/routes/festival/[festival_id]/edit/+page.svelte
+++ b/src/routes/festival/[festival_id]/edit/+page.svelte
@@ -1,28 +1,26 @@
 <script lang="ts">
+	import { untrack } from 'svelte';
 	import { dateToHHMM, dateToString } from '$lib/utils/date.util';
 	import type { FrontendFestivalEvent } from '$lib/models/festivalEvent/FrontendFestivalEvent';
 
 	let { data }: { data: FrontendFestivalEvent } = $props();
 
-	let formData = $state({
-		name: '',
-		description: '',
-		startDate: '',
-		startTime: '',
-		location: '',
-		bringYourOwnFood: false,
-		bringYourOwnBottle: false
-	});
-
-	$effect(() => {
-		formData.name = data?.name ?? '';
-		formData.description = data?.description ?? '';
-		formData.startDate = dateToString(data.startDate);
-		formData.startTime = dateToHHMM(data.startDate);
-		formData.location = data.location ?? '';
-		formData.bringYourOwnFood = data.bringYourOwnFood;
-		formData.bringYourOwnBottle = data.bringYourOwnBottle;
-	});
+	// Formular einmalig aus data vorbefüllen (gilt für SSR und Client). Bewusst KEIN $effect,
+	// der formData nachträglich aus data setzt: Der Effect liefe erst nach der Hydration und
+	// würde eine bereits getätigte Eingabe (bind:value) wieder mit den Altwerten überschreiben
+	// – ein Race, der zum Speichern der alten Werte führt. untrack signalisiert Svelte, dass
+	// der einmalige Snapshot von data hier gewollt ist (kein reaktives Nachziehen).
+	let formData = $state(
+		untrack(() => ({
+			name: data?.name ?? '',
+			description: data?.description ?? '',
+			startDate: dateToString(data.startDate),
+			startTime: dateToHHMM(data.startDate),
+			location: data.location ?? '',
+			bringYourOwnFood: data.bringYourOwnFood,
+			bringYourOwnBottle: data.bringYourOwnBottle
+		}))
+	);
 </script>
 
 <article>

--- a/tests/festival.spec.ts
+++ b/tests/festival.spec.ts
@@ -67,7 +67,6 @@ test.describe.serial('Festival-Management Lifecycle', () => {
 		const nameInput = page.locator('input[name="name"]');
 		await expect(nameInput).toBeVisible({ timeout: 15000 });
 		await nameInput.fill(updatedFestivalName);
-		await page.waitForTimeout(500);
 
 		const descriptionInput = page.locator('textarea[name="description"]');
 		await descriptionInput.fill('Aktualisierte Beschreibung für den Test.');
@@ -92,17 +91,7 @@ test.describe.serial('Festival-Management Lifecycle', () => {
 			page.waitForURL(new RegExp(`/festival/${festivalId}$`), { timeout: 15000 }),
 			saveButton.click()
 		]);
-		await page.waitForLoadState('networkidle');
-		// Explizit zur Detailseite navigieren und auf aktualisierten Namen warten
-		// webkit cached SSR-Responses – retry bis der neue Name erscheint
-		await page.goto(`/festival/${festivalId}`, { waitUntil: 'networkidle' });
-		let attempts = 0;
-		while (attempts < 5) {
-			const text = await page.locator('h4 u').textContent();
-			if (text && text.includes(updatedFestivalName)) break;
-			await page.reload({ waitUntil: 'networkidle' });
-			attempts++;
-		}
+		// Nach dem Redirect muss der aktualisierte Name auf der Detailseite stehen.
 		await expect(page.locator('h4 u')).toContainText(updatedFestivalName, { timeout: 15000 });
 		// TODO await expect(page.locator('p')).toContainText('Aktualisierte Beschreibung für den Test.');
 		// await expect(page.locator('input[name="bringYourOwnFood"]')).not.toBeChecked();


### PR DESCRIPTION
Follow-up nach dem `groups`-Merge: der letzte CI-Flake und die DB-Sync-Einstellung.

## 1. Festival-Edit-Race (behebt `festival.spec:106`)
`edit/+page.svelte` befüllte `formData` per `$effect` aus `data`. Der Effect läuft **erst nach der Hydration** und überschrieb eine bereits getippte Eingabe (`bind:value`) wieder mit den Altwerten → es wurde der **alte** Festival-Name gespeichert. Dieselbe Bug-Klasse wie der zuvor behobene Kommentar-Bug — ein echtes Produktionsproblem auf langsamen Geräten, nicht nur ein Testartefakt.

**Fix:** `formData` einmalig aus `data` initialisieren (`$state(untrack(() => ({…})))`, gilt für SSR und Client), kein nachziehender Effect. Der Test wurde entschlackt (500ms-`waitForTimeout` + 5-fach-Reload-Workaround raus).

## 2. DB-Sync vereinfacht
`startDB()` nutzt jetzt **immer `alter`** — die ganze `force`-Verzweigung ist weg. Begründung: Test-/Dev-Umgebungen laufen als frisches In-Memory-SQLite (`sequelize.ts`), wo `alter` die Tabellen ohnehin von Grund auf erzeugt; Produktion (MariaDB) erhält mit `alter` die Daten. Ein `force` (kompletter Wipe) wird also **nirgends** gebraucht. Sauberkeit zwischen E2E-Tests macht weiterhin `/api/test/reset`, nicht der Sync-Modus. Der ungenutzte `env`/`MARIA_DB_NAME`-Import ist ebenfalls raus.

## 3. Kleinigkeit
Zweite, unkritische Instanz des `$effect`-schreibt-`bind:value`-Musters (Dialog-Vorbefüllung in der Festival-Detailseite) als TODO erfasst.

**Verifiziert:** volle Suite mehrfach bei `retries=0` grün, `svelte-check` 0/0, `vitest` 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)