### PR TITLE
Deploy-Health-Check-Fenster auf ~10 min + Version 0.6.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,14 +42,18 @@ jobs:
             # ANNAHME: Supervisor-Service heißt "festival" – bei Bedarf anpassen
             # (Name prüfen mit `supervisorctl status` auf dem Uberspace-Host).
             supervisorctl restart festival
-            # Warten, bis der Dev-Server wieder auf Port 5173 antwortet. Großzügig, da
-            # start-server erst `npm install` ausführt, bevor vite startet (max. ~3 min).
-            for i in $(seq 1 60); do
+            # Warten, bis der Dev-Server wieder auf Port 5173 antwortet. Sehr großzügig
+            # (bis ~10 min), da start-server bei jedem Neustart erst `npm install` ausführt
+            # und dieser Kaltstart auf Uberspace mehrere Minuten dauern kann, in denen der
+            # Port geschlossen ist. (Eigentlicher Fix wäre adapter-node statt vite dev –
+            # siehe TODO, dann startet der Service in Sekunden.)
+            for i in $(seq 1 120); do
               if curl -fsS -o /dev/null http://localhost:5173/; then
-                echo "Service ist nach dem Restart erreichbar."
+                echo "Service ist nach dem Restart erreichbar (nach ~$((i * 5))s)."
                 exit 0
               fi
-              sleep 3
+              [ $((i % 6)) -eq 0 ] && echo "warte auf Service... (~$((i * 5))s)"
+              sleep 5
             done
-            echo "Service kam nach dem Restart nicht hoch (Port 5173 nicht erreichbar)."
+            echo "Service kam nach dem Restart nicht hoch (Port 5173 nach ~10 min nicht erreichbar)."
             exit 1

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "festival",
-	"version": "0.6.1",
+	"version": "0.6.2",
 	"private": true,
 	"license": "MIT",
 	"scripts": {


### PR DESCRIPTION
Folgt auf den roten Deploy von #24 (Fehlalarm).

## Problem
Der Health-Check nach `supervisorctl restart festival` schlug fehl, obwohl der Service korrekt neu startete. Ursache: `start-server` (= `npm install && vite dev`) führt bei **jedem** Neustart erst `npm install` aus; dieser Kaltstart hält Port 5173 auf Uberspace mehrere Minuten geschlossen und überschritt das bisherige 3-min-Fenster. Verifiziert per `supervisorctl status festival` → `RUNNING` (Prod lief nach dem Deploy normal weiter).

## Änderung
- Health-Check-Fenster von ~3 min auf **~10 min** erhöht + Fortschritts-Logging.
- `package.json` **0.6.1 → 0.6.2** (Versions-Bump gehört ab jetzt zu jedem Update dazu).

## Hinweis (TODO steht schon)
Der eigentliche Fix ist `@sveltejs/adapter-node` (`vite build` → `node build`) statt `vite dev` in Produktion — dann startet der Service in Sekunden und der Health-Check braucht kein Minuten-Fenster.

> Merge löst einen Deploy aus, der die Produktion neu startet (~einige Minuten `npm install`-Kaltstart, dann grün durch das größere Fenster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)