### PR TITLE
Serverseitige Bild-Upload-Validierung (v0.7.1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,7 +21,6 @@ Sortiert nach **Aufwand** (S → M → L), innerhalb jeder Stufe nach **Priorit�
 
 ## [S] Klein (< 1h)
 
-- [ ] 🟡 **Bild-Upload serverseitig validieren:** Der `POST /user-image`-Endpoint speichert den Base64-Body ungeprüft. Die 1-MB-Grenze und der Typ (`.png/.jpg`) werden nur clientseitig in `AvatarUpload.svelte` geprüft. Größe und MIME-Typ serverseitig validieren. _(Sicherheit)_
 - [ ] 🟡 **Dokumentation:** Produktions-Umgebung (env) sauber dokumentieren. _(Deployment)_
 - [ ] 🟢 **E-Mail-Eindeutigkeit beim Update:** Die Profil-Update-Action (`user/[user_id]/+page.server.ts`) prüft die Eindeutigkeit des Nicknames, aber nicht der E-Mail (`UserService.emailInvalid` existiert, wird bei Registrierung genutzt). Beim Ändern der E-Mail ebenfalls prüfen. _(Datenschutz)_
 - [ ] 🟢 **Fremdschlüssel-Casing:** Der Workaround `event.UserId || (event as any).userId` (in `src/lib/db/attributes/festivalEvent.attributes.ts:26,49` und `src/lib/services/festival-event.service.ts:95,119`) deutet auf uneinheitliches FK-Casing hin. FK-Namen laut Triad-Regel eindeutig auf `UserId` festlegen und die `as any`-Krücke entfernen. _(Datenbank)_

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "festival",
-	"version": "0.7.0",
+	"version": "0.7.1",
 	"private": true,
 	"license": "MIT",
 	"scripts": {

--- a/src/lib/services/image.logic.spec.ts
+++ b/src/lib/services/image.logic.spec.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { validateImageDataUri, MAX_IMAGE_BYTES } from './image.logic';
+
+/** Erzeugt eine Data-URI mit einem Base64-Payload gegebener dekodierter Byte-Länge. */
+function dataUriOfSize(mime: string, bytes: number): string {
+	// 'A' wiederholt ergibt gültiges Base64; ceil(bytes*4/3) Zeichen ~ bytes Byte.
+	const chars = Math.ceil((bytes * 4) / 3);
+	return `data:${mime};base64,${'A'.repeat(chars)}`;
+}
+
+describe('validateImageDataUri', () => {
+	it('akzeptiert ein kleines PNG', () => {
+		const result = validateImageDataUri(
+			'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+		);
+		expect(result.valid).toBe(true);
+	});
+
+	it('akzeptiert JPEG', () => {
+		expect(validateImageDataUri(dataUriOfSize('image/jpeg', 1024)).valid).toBe(true);
+	});
+
+	it('lehnt einen nicht erlaubten Typ ab', () => {
+		const result = validateImageDataUri(dataUriOfSize('image/gif', 100));
+		expect(result).toMatchObject({ valid: false, error: 'type' });
+	});
+
+	it('lehnt SVG (XSS-Risiko) ab', () => {
+		const result = validateImageDataUri(dataUriOfSize('image/svg+xml', 100));
+		expect(result).toMatchObject({ valid: false, error: 'type' });
+	});
+
+	it('lehnt einen String ohne Data-URI-Präfix ab', () => {
+		const result = validateImageDataUri('iVBORw0KGgoAAAANSUhEUg');
+		expect(result).toMatchObject({ valid: false, error: 'malformed' });
+	});
+
+	it('lehnt ein leeres Bild ab', () => {
+		const result = validateImageDataUri('data:image/png;base64,');
+		expect(result).toMatchObject({ valid: false, error: 'empty' });
+	});
+
+	it('lehnt ein Bild über 1 MB ab', () => {
+		const result = validateImageDataUri(dataUriOfSize('image/png', MAX_IMAGE_BYTES + 1024));
+		expect(result).toMatchObject({ valid: false, error: 'size' });
+	});
+
+	it('akzeptiert ein Bild exakt an der Größengrenze', () => {
+		expect(validateImageDataUri(dataUriOfSize('image/png', MAX_IMAGE_BYTES)).valid).toBe(true);
+	});
+});

--- a/src/lib/services/image.logic.ts
+++ b/src/lib/services/image.logic.ts
@@ -1,0 +1,61 @@
+/**
+ * Reine Validierungslogik für hochgeladene Profilbilder.
+ *
+ * Der Client sendet das Bild als Data-URI (`data:<mime>;base64,<payload>`) und prüft
+ * Größe/Typ nur clientseitig (AvatarUpload.svelte). Diese Logik ist das serverseitige
+ * Gegenstück und wird im `POST /user-image`-Endpoint erzwungen.
+ */
+
+/** Maximal erlaubte Bildgröße in Byte (1 MB) – deckt sich mit der Client-Prüfung. */
+export const MAX_IMAGE_BYTES = 1_048_576;
+
+/** Erlaubte MIME-Typen (der File-Input akzeptiert nur .png/.jpg). */
+export const ALLOWED_IMAGE_MIME_TYPES = ['image/png', 'image/jpeg', 'image/jpg'] as const;
+
+/** Maschinenlesbarer Fehlergrund – der Endpoint mappt ihn auf einen HTTP-Status. */
+export type ImageValidationError = 'malformed' | 'type' | 'size' | 'empty';
+
+export type ImageValidationResult =
+	| { valid: true; mime: string }
+	| { valid: false; error: ImageValidationError; reason: string };
+
+/**
+ * Ermittelt die dekodierte Byte-Länge eines Base64-Strings ohne ihn tatsächlich zu dekodieren.
+ */
+function base64ByteLength(base64: string): number {
+	const len = base64.length;
+	if (len === 0) {
+		return 0;
+	}
+	const padding = base64.endsWith('==') ? 2 : base64.endsWith('=') ? 1 : 0;
+	return Math.floor((len * 3) / 4) - padding;
+}
+
+/**
+ * Validiert eine als Data-URI übergebene Bilddatei gegen erlaubten Typ und maximale Größe.
+ *
+ * @param dataUri - z. B. `data:image/png;base64,iVBORw0K...`
+ */
+export function validateImageDataUri(dataUri: string): ImageValidationResult {
+	const match = /^data:([^;,]+);base64,(.*)$/s.exec(dataUri.trim());
+	if (!match) {
+		return { valid: false, error: 'malformed', reason: 'Ungültiges Bildformat (Base64-Data-URI erwartet).' };
+	}
+
+	const mime = match[1].toLowerCase();
+	const payload = match[2];
+
+	if (!(ALLOWED_IMAGE_MIME_TYPES as readonly string[]).includes(mime)) {
+		return { valid: false, error: 'type', reason: `Nicht erlaubter Bildtyp: ${mime}. Erlaubt sind PNG und JPG.` };
+	}
+
+	const sizeInBytes = base64ByteLength(payload);
+	if (sizeInBytes === 0) {
+		return { valid: false, error: 'empty', reason: 'Leeres Bild.' };
+	}
+	if (sizeInBytes > MAX_IMAGE_BYTES) {
+		return { valid: false, error: 'size', reason: 'Bild zu groß (max. 1 MB).' };
+	}
+
+	return { valid: true, mime };
+}

--- a/src/routes/user-image/+server.ts
+++ b/src/routes/user-image/+server.ts
@@ -2,6 +2,15 @@ import type { Cookies } from '@sveltejs/kit';
 import type { RequestHandler } from './$types';
 import { SessionTokenUser } from '$lib/models/user/SessionTokenUser';
 import { UserService } from '$lib/services/user.service';
+import { validateImageDataUri, type ImageValidationError } from '$lib/services/image.logic';
+
+/** Mappt einen Validierungsfehler auf einen passenden HTTP-Status. */
+const STATUS_FOR_IMAGE_ERROR: Record<ImageValidationError, number> = {
+	malformed: 400,
+	empty: 400,
+	type: 415, // Unsupported Media Type
+	size: 413 // Payload Too Large
+};
 
 /**
  * POST /user-image
@@ -10,8 +19,9 @@ import { UserService } from '$lib/services/user.service';
  * Erwartet das Bild als Base64-kodierten String im Request-Body.
  *
  * @param cookies - Session-Cookie zur Authentifizierung
- * @param request - Body enthält das Bild als Base64-String (Plaintext)
- * @returns 200 bei Erfolg, 401 wenn nicht eingeloggt, 400 bei fehlendem Body oder Bilddaten
+ * @param request - Body enthält das Bild als Base64-Data-URI (Plaintext)
+ * @returns 200 bei Erfolg, 401 wenn nicht eingeloggt, 400 bei fehlendem Body,
+ *          415 bei nicht erlaubtem Typ, 413 wenn zu groß
  */
 export const POST: RequestHandler = async ({
 	cookies,
@@ -28,6 +38,11 @@ export const POST: RequestHandler = async ({
 			return new Response('Unauthorized', { status: 401 });
 		}
 		if (base64Img) {
+			// Serverseitige Validierung (Größe/Typ) – die Client-Prüfung ist umgehbar.
+			const validation = validateImageDataUri(base64Img);
+			if (!validation.valid) {
+				return new Response(validation.reason, { status: STATUS_FOR_IMAGE_ERROR[validation.error] });
+			}
 			await UserService.saveUserImage(extractUser.id, base64Img);
 			return new Response(null, { status: 200 });
 		}

--- a/tests/settings.spec.ts
+++ b/tests/settings.spec.ts
@@ -105,4 +105,23 @@ test.describe('Benutzereinstellungen und Profilbild', () => {
 		// In AvatarImage wird das Bild als Base64 geladen oder via API
 		expect(src).toBeTruthy();
 	});
+
+	test('sollte einen serverseitig ungültigen Upload ablehnen', async ({ page }) => {
+		await register(page, `BadUpload_User_${Date.now()}`, 'InitialPassword123!');
+
+		// Direkt gegen den Endpoint (umgeht die clientseitige Prüfung in AvatarUpload.svelte).
+		// page.evaluate -> Browser sendet seine Session-Cookies mit.
+		const results = await page.evaluate(async () => {
+			const post = (body: string) => fetch('/user-image', { method: 'POST', body }).then((r) => r.status);
+			return {
+				wrongType: await post('data:image/gif;base64,R0lGODlhAQABAAAAACw='),
+				tooBig: await post('data:image/png;base64,' + 'A'.repeat(1_500_000)),
+				malformed: await post('kein-data-uri')
+			};
+		});
+
+		expect(results.wrongType).toBe(415);
+		expect(results.tooBig).toBe(413);
+		expect(results.malformed).toBe(400);
+	});
 });


### PR DESCRIPTION
Kleiner TODO: `POST /user-image` speicherte den Base64-Body bisher **ungeprüft** — Größe (1 MB) und Typ (png/jpg) wurden nur clientseitig in `AvatarUpload.svelte` geprüft und ließen sich damit umgehen.

## Änderung
- Neue reine Validierungslogik `src/lib/services/image.logic.ts`: parst die Data-URI, prüft MIME gegen eine Whitelist (png/jpeg) und die **dekodierte** Byte-Größe.
- Im Endpoint erzwungen, mit passenden Status-Codes: **415** (nicht erlaubter Typ), **413** (zu groß), **400** (malformed/leer).
- **SVG wird abgelehnt** (XSS-Risiko bei inline gerenderten SVGs).

## Tests
- 8 Unit-Tests (`image.logic.spec.ts`) inkl. Grenzfälle (exakt 1 MB, leer, SVG, kein Präfix).
- E2E-Test, der den Endpoint **direkt** mit ungültigen Uploads anspricht (umgeht die Client-Prüfung) und 415/413/400 erwartet.
- Happy-Path-Upload weiterhin grün. Volle Suite **47/47**, `svelte-check` 0/0, `vitest` 14/14.

Version **0.7.0 → 0.7.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)